### PR TITLE
Remove duplicated in sortOnSave description

### DIFF
--- a/package.json
+++ b/package.json
@@ -235,7 +235,7 @@
         "windicss.sortOnSave": {
           "type": "boolean",
           "default": false,
-          "description": "A flag that controls whether or not Windi CSS classes will be sorted on save on save."
+          "description": "A flag that controls whether or not Windi CSS classes will be sorted on save."
         },
         "windicss.includeLanguages": {
           "type": "object",


### PR DESCRIPTION
This PR remove a duplicate `on save` from the `windcss.sortOnSave` description