### PR TITLE
feat: support for postcss files

### DIFF
--- a/src/utils/filetypes.ts
+++ b/src/utils/filetypes.ts
@@ -36,6 +36,9 @@ export const fileTypes: {[key:string]: {pattern?: RegExp, type: string}} = {
   'less': {
     type: 'css',
   },
+  'postcss': {
+    type: 'css',
+  },
   'javascript': {
     type: 'js',
   },


### PR DESCRIPTION
Today when I write my project, I found I can't get suggestions in css file, but I remember that it was fixed before, finally I found VS Code detect my css file as postcss file automatically,I even don't know how it happened, so I think it looks like VS Code extension works: give priority to identifying what it thinks is the type, it is necessary to add this feature.