### PR TITLE
fix: static completions when using prefix

### DIFF
--- a/src/utils/completions.ts
+++ b/src/utils/completions.ts
@@ -256,7 +256,7 @@ export function generateCompletions(processor: Processor, colors: colorObject, a
     }
   }
 
-  completions.static.push(...Object.keys(staticUtilities));
+  completions.static.push(...Object.keys(staticUtilities).map((key) => prefix + key));
   completions.attr = attr;
   return completions;
 }


### PR DESCRIPTION
Fixed a problem where some completions did not work when using a prefix.

This is a screencast when `tw-`prefix setting. (v0.21.4)
[![Image from Gyazo](https://i.gyazo.com/69d5610184024e23960171245bdf8b77.gif)](https://gyazo.com/69d5610184024e23960171245bdf8b77)