### PR TITLE
createFileSystemWatcher takes RelativePattern object

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -97,7 +97,7 @@ export default class Extension {
   }
 
   watch() {
-    const watcher = workspace.createFileSystemWatcher(`${this.pattern}`);
+    const watcher = workspace.createFileSystemWatcher(this.pattern);
 
     // Changes configuration should invalidate above cache
     watcher.onDidChange((e) => {


### PR DESCRIPTION
Watcher does not fire on config file change because of RelativePattern object to string conversion