### PR TITLE
feat: hover tip support `windi` & `Windi` as prefix

### DIFF
--- a/src/lib/hovers.ts
+++ b/src/lib/hovers.ts
@@ -43,7 +43,7 @@ export default class Hovers {
         // hover attr value or class value, e.g. class="bg-red-500 ..."  bg="red-500 ..."
         const text = document.getText(new Range(new Position(0, 0), position));
         const key = text.match(/\S+(?=\s*(=|:)\s*["']?[^"']*$)/)?.[0] ?? '';
-        const style = this.extension.isAttr(key) ? this.processor.attributify({ [key]: [ word ] }) : ['className', 'class'].includes(key) || text.match(applyRegex) ? this.processor.interpret(word) : undefined;
+        const style = this.extension.isAttr(key) ? this.processor.attributify({ [key]: [ word ] }) : ['className', 'class', 'windi', 'Windi'].includes(key) || text.match(applyRegex) ? this.processor.interpret(word) : undefined;
         if (style && style.ignored.length === 0) {
           const css = buildStyle(style.styleSheet);
           if (css) return new Hover(css, range);


### PR DESCRIPTION
## Changes

As `Windi` and `windi` can trigger completions, I think both of them can trigger hovers too!

![image](https://user-images.githubusercontent.com/27187946/149623664-dae615f8-949a-4f98-91d6-63ec8cac5ec1.png)
