### PR TITLE
fix: hover ``div(class=`` in pug file

### DIFF
--- a/src/lib/hovers.ts
+++ b/src/lib/hovers.ts
@@ -42,7 +42,7 @@ export default class Hovers {
 
         // hover attr value or class value, e.g. class="bg-red-500 ..."  bg="red-500 ..."
         const text = document.getText(new Range(new Position(0, 0), position));
-        const key = text.match(/\S+(?=\s*(=|:)\s*["']?[^"']*$)/)?.[0] ?? '';
+        const key = text.match(/[^\s\(]+(?=\s*(=|:)\s*["']?[^"']*$)/)?.[0] ?? '';
         const style = this.extension.isAttr(key) ? this.processor.attributify({ [key]: [ word ] }) : ['className', 'class', 'windi', 'Windi'].includes(key) || text.match(applyRegex) ? this.processor.interpret(word) : undefined;
         if (style && style.ignored.length === 0) {
           const css = buildStyle(style.styleSheet);


### PR DESCRIPTION
Fix the problem when hovering ``div(class=`` in pug files.

![problem](https://user-images.githubusercontent.com/5630262/152503878-b5ba89f6-98c8-482c-8d9b-cb92d77c74cf.gif)


After: 

![after](https://user-images.githubusercontent.com/5630262/152503935-d47dd31b-0a09-4086-8c1b-a43aa44805c0.gif)

