### PR TITLE
Handle edge case of /* // inside strings caught as unclosed comment

### DIFF
--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -10,7 +10,7 @@ export class HTMLParser {
 
   removeComments() {
     if (!this.html) return [];
-    const regex = /\/\*[\s\S]*?\*\/|\/\*[\s\S]*$|([^\\:]|^)\/\/.*|<!--[\s\S]*?-->$/igm;
+    const regex = (?!.*\")\/\*[\s\S]*?\*\/|(?<![\d\w-]=\".*)\/\*[\s\S]*$|([^\\:]|^)(?!.*\")\/\/.*|<!--[\s\S]*?-->$/igm;
     let match;
     while ((match = regex.exec(this.html as string))) {
       if (match) {


### PR DESCRIPTION
removeComments() considers an attribute like `accept="image/*"` as an opening `/*` comment; worse, it never closes so everything following `/*` is removed. Fix regex to ignore `/*` and `//` inside strings.